### PR TITLE
fix: member - fix logic: get userId from securityContext

### DIFF
--- a/src/main/java/org/paz/community/member/controller/MemberController.java
+++ b/src/main/java/org/paz/community/member/controller/MemberController.java
@@ -4,7 +4,9 @@ import io.swagger.v3.oas.annotations.Operation;
 import org.paz.community.member.domain.Member;
 import org.paz.community.member.dto.MemberDto;
 import org.paz.community.member.service.MemberServiceImpl;
+import org.paz.community.member.userDetails.CustomUserDetails;
 import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -63,8 +65,8 @@ public class MemberController {
 
     @GetMapping("/") // 회원 정보 조회(수정을 위한)
     @Operation(summary="회원 정보 조회")
-    public MemberDto.Info readInfo(){
-        MemberDto.Info result = commonMemberService.readInfo();
+    public MemberDto.Info readInfo(@AuthenticationPrincipal CustomUserDetails userDetails){
+        MemberDto.Info result = commonMemberService.readInfo(userDetails.getId());
         return result;
     }
     @PatchMapping(value="/", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE, MediaType.APPLICATION_JSON_VALUE}) // 회원 정보 수정

--- a/src/main/java/org/paz/community/member/service/MemberService.java
+++ b/src/main/java/org/paz/community/member/service/MemberService.java
@@ -20,7 +20,7 @@ public interface MemberService{
     // 로그아웃
 
     // find by id
-    MemberDto.Info readInfo();
+    MemberDto.Info readInfo(Long authenticatedId);
     // 회원정보 수정
     void modifyInfo(MemberDto.ModifyInfo dto, List<MultipartFile> file);
     // 비밀번호 변경


### PR DESCRIPTION
기존의 security Context에서 현재 인증된 사용자의 정보를 가져오는 서비스 로직을 컨트롤러에서 @AuthenticationPrincipal을 통해 불러오는 로직으로 변경